### PR TITLE
Ensure correct rails version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - "2.7"
           - "3.0"
           - "3.1"
           - "3.2"
@@ -32,7 +31,7 @@ jobs:
     env:
       BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails }}.gemfile
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "activemodel", "~> 6.1"
+gem "activemodel", "~> 6.1.7"
 
 # pull the ART19 patched version of cassandra-driver
 source 'https://rubygems.pkg.github.com/art19' do

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "activemodel", "~> 7.0"
+gem "activemodel", "~> 7.0.8"
 
 # pull the ART19 patched version of cassandra-driver
 source 'https://rubygems.pkg.github.com/art19' do

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "activemodel", "~> 7.1"
+gem "activemodel", "~> 7.1.3"
 
 # pull the ART19 patched version of cassandra-driver
 source 'https://rubygems.pkg.github.com/art19' do


### PR DESCRIPTION
The minor version was floating for 7.0 to 7.1. If/when 7.2 is released both 7.0 and 7.1 would instead be testing 7.2.